### PR TITLE
add nice privacy concerned social sharing buttons to the post pages

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,10 +25,17 @@ layout: default
     {% endif %}
     &middot;
     {{ page.date | date_to_long_string }}
+    <script type="text/javascript">
+      reddit_url = "{{  site.production_url  }}{{ page.url }}";
+    </script>
+    <script type="text/javascript" src="//www.redditstatic.com/button/button1.js"></script>
   </span>
     <div class="post_content">
     {{ content }}
     </div>
+<div class="row">
+  <div  data-order="reddit twitter facebook hackernews googleplus linkedin email" data-social-share-privacy='true'></div>
+</div>
 
 <div class="row">
   <div id="the_author" class="team_list">
@@ -89,4 +96,7 @@ layout: default
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
     })();
   </script>
+  <script type="application/x-social-share-privacy-settings">{"path_prefix":"http://panzi.github.io/SocialSharePrivacy/","layout":"box","uri":"{{  site.production_url  }}{{ page.url }}","services":{"buffer":{"status":false},"delicious":{"status":false},"disqus":{"status":false},"fbshare":{"status":false},"flattr":{"status":false},"pinterest":{"status":false},"stumbleupon":{"status":false},"tumblr":{"status":false},"xing":{"status":false}}}</script>
+   <script type="text/javascript" src="http://panzi.github.io/SocialSharePrivacy/javascripts/jquery.cookies.js"></script>
+   <script type="text/javascript">(function () {var s = document.createElement('script');var t = document.getElementsByTagName('script')[0];s.type = 'text/javascript';s.async = true;s.src = 'http://panzi.github.io/SocialSharePrivacy/javascripts/jquery.socialshareprivacy.min.autoload.js';t.parentNode.insertBefore(s, t);})();</script>
 </div>

--- a/css/main.css
+++ b/css/main.css
@@ -335,3 +335,25 @@ strong {
   color: #20A260;
   font-weight: normal;
 }
+
+/*
+Social Share buttons additions
+*/
+
+.row .social_share_privacy_area.box  {
+  width: 100% !important;
+}
+.social_share_privacy_area.box li {
+  display: inline-block !important;
+  width: 95px;
+}
+
+.post_meta {
+  position: relative;
+}
+.post_meta iframe {
+  display: inline-block !important;
+  position: relative;
+  top: 6px;
+  margin-left: 10px;
+}


### PR DESCRIPTION
After looking into our Analytics data, I realised that we should be stronger on reddit integration. So I added social sharing buttons – privacy concerned of course – to the blog pages. Not only for reddit but for all kinds of networks. Check it out:

This is the reddit share in the top of a post (not on overview pages):
![screen shot 2015-06-10 at 15 54 24](https://cloud.githubusercontent.com/assets/40496/8084193/06471df6-0f8a-11e5-9130-4cb75529f387.png)

Then after the content, before the Author, we have a ton of more buttons – including email
![screen shot 2015-06-10 at 15 54 35](https://cloud.githubusercontent.com/assets/40496/8084199/18a0819a-0f8a-11e5-8cbf-a4c5f3f9e95d.png)

Which, once switched on (on a one-by-one basis), look nice and shiny like this:
![screen shot 2015-06-10 at 15 54 53](https://cloud.githubusercontent.com/assets/40496/8084211/29e59a58-0f8a-11e5-99d8-807041ad9c35.png)

WhoopWhoop!!


 